### PR TITLE
[hotfix] Update the running scripts to run kfusion in Jenkins exclusively on one backend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,7 +196,7 @@ void buildAndTest(String JDK, String tornadoProfile) {
         sleep 5
         timeout(time: 5, unit: 'MINUTES') {
             sh "cd ${KFUSION_ROOT} && sed -i 's/kfusion.tornado.backend=PTX/kfusion.tornado.backend=OpenCL/' conf/kfusion.settings"
-            sh 'cd ${KFUSION_ROOT} && ./scripts/run.sh'
+            sh 'cd ${KFUSION_ROOT} && ./scripts/runOnlyOpenCL.sh'
 
         }
     }
@@ -204,7 +204,7 @@ void buildAndTest(String JDK, String tornadoProfile) {
         sleep 5
         timeout(time: 5, unit: 'MINUTES') {
             sh "cd ${KFUSION_ROOT} && sed -i 's/kfusion.tornado.backend=OpenCL/kfusion.tornado.backend=PTX/' conf/kfusion.settings"
-            sh 'cd ${KFUSION_ROOT} && ./scripts/run.sh'
+            sh 'cd ${KFUSION_ROOT} && ./scripts/runOnlyPTX.sh'
         }
     }
 }


### PR DESCRIPTION
#### Description

Following the PR that was merged earlier in the kfusion repository ([here](https://github.com/beehive-lab/kfusion-tornadovm/pull/38)), I made the update for the running scripts of running `kfusion` with TornadoVM in Jenkins for exclusive backend (OpenCL, or PTX). As a note, SPIR-V is not supported in this use case.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

The change affects only the Jenkinsfile.

----------------------------------------------------------------------------
