### PR TITLE
Correct typo for benchmarks

### DIFF
--- a/tornado-assembly/src/bin/tornado-benchmarks-training.py
+++ b/tornado-assembly/src/bin/tornado-benchmarks-training.py
@@ -602,7 +602,7 @@ def runBenchmarksFullCoverage(args):
                     + " "
                     + str(size)
             )
-            if key == "sgemm":
+            if key == ["sgemm", "dgemm"]:
                 command = command + " " + str(size)
             command += '"'
             print(command)

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/matrixMultiplication1D/Benchmark.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/matrixMultiplication1D/Benchmark.java
@@ -37,7 +37,7 @@ public class Benchmark extends BenchmarkRunner {
 
     @Override
     protected String getName() {
-        return "matrixVectorMultiplication";
+        return "matrixMultiplication1D";
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/matrixMultiplication2D/Benchmark.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/matrixMultiplication2D/Benchmark.java
@@ -37,7 +37,7 @@ public class Benchmark extends BenchmarkRunner {
 
     @Override
     protected String getName() {
-        return "matrixAddition";
+        return "matrixMultiplication2D";
     }
 
     @Override


### PR DESCRIPTION
Correct typos for matrixMultiplication1D, matrixMultiplication2D, and fix the commend for dgemm